### PR TITLE
Reposition

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,8 @@ from content import Content
 class App:
     
     def __init__(self, master):
+        # Prevent the app window from being resized
+        master.resizable(False, False)
         default_image_path = 'images/gimp_themes/maple_leaves.png'
         self.banner = Banner(master, default_image_path)
         self.content = Content(master)

--- a/content.py
+++ b/content.py
@@ -45,6 +45,7 @@ class Content:
     def add_task(self):
         # Create and configure the window for adding tasks
         add_window = Toplevel(self.checklist_frame, width=480, height=40)
+        add_window.title('Add Task')
         # Prevent window resizing along x and y
         add_window.resizable(False, False)
         # Offset is by default relative to the screen; need offset relative to the parent widget

--- a/content.py
+++ b/content.py
@@ -4,6 +4,10 @@ from tkinter import Toplevel
 from tkinter import messagebox
 from item import ChecklistItem
 
+# REFERENCES
+# Control the placement of a TopLevel Window: 'Creating additional top-level windows' from 'Python GUI Development with Tkinter' course on LinkedIn Learning with Barron Stone [5:27]
+# Fix issue where winfo_width() and winfo_height() always return 1: https://stackoverflow.com/questions/34373533/winfo-width-returns-1-even-after-using-pack
+
 class Content:
     
     def __init__(self, master, checklist=None):
@@ -39,10 +43,19 @@ class Content:
             task.item.pack(anchor='w', pady=5, padx=5)
 
     def add_task(self):
-        # Create widgets
-        add_window = Toplevel(self.button_frame, height=120, width=480)
+        # Create and configure the window for adding tasks
+        add_window = Toplevel(self.checklist_frame, width=480, height=40)
         # Prevent window resizing along x and y
         add_window.resizable(False, False)
+        # Offset is by default relative to the screen; need offset relative to the parent widget
+        offset_x = self.checklist_frame.winfo_rootx() - 8
+        offset_y = self.checklist_frame.winfo_rooty() + int(self.checklist_frame.winfo_height()/3)
+        # Call to update_idletasks() required to fix issue where winfo_width() and winfo_height() always return 1
+        add_window.update_idletasks()
+        # Make the window to add tasks appear on top and around the middle of the checklist frame
+        add_window.geometry("{}x{}+{}+{}".format(add_window.winfo_width(), add_window.winfo_height(), offset_x, offset_y))
+
+        # Create widgets for window to add tasks
         add_frame = ttk.Frame(add_window)
         add_label = ttk.Label(add_frame, text="Task Name: ")
         add_entry = ttk.Entry(add_frame, width=48)
@@ -51,9 +64,9 @@ class Content:
         cancel_button = Button(add_frame, text="Cancel", command=lambda: self.cancel(add_window))
 
         # Place widgets
-        add_label.pack(side='left')
-        add_entry.pack(side='left')
-        submit_button.pack(side='left')
+        add_label.pack(side='left', pady=10)
+        add_entry.pack(side='left', pady=10)
+        submit_button.pack(side='left', padx=5)
         cancel_button.pack(side='left')
         add_frame.pack()
 


### PR DESCRIPTION
This update makes the 'Add Task' window appear above and around the centre of the checklist frame (there was no control in terms of placement of the window before).
The size of the 'Add Task' window is also now explicitly set and no longer dependent on the size of the widgets within.
The 'Add Task' window also now has a title namely 'Add Task'.
The padding for the widgets within the 'Add Task' window have also been changed to be more centred and the 'Submit' and 'Cancel' buttons now have space between them.